### PR TITLE
인덱스를 활용한 쿼리 성능 개선

### DIFF
--- a/src/main/java/kr/hhplus/be/server/order/domain/OrderItem.java
+++ b/src/main/java/kr/hhplus/be/server/order/domain/OrderItem.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Entity
 @Table(name = "order_item", indexes = {
-        @Index(name = "idx_order_item_product_created", columnList = "product_id, created_at")
+        @Index(name = "idx_order_item_product_created", columnList = "product_id, created_at, quantity")
 })
 public class OrderItem extends BaseEntity {
 

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,0 +1,35 @@
+SET SESSION cte_max_recursion_depth = 1000000;
+
+DROP TEMPORARY TABLE IF EXISTS temp_numbers;
+CREATE TEMPORARY TABLE temp_numbers (n INT PRIMARY KEY);
+
+INSERT INTO temp_numbers (n)
+WITH RECURSIVE numbers AS (
+    SELECT 1 AS n
+    UNION ALL
+    SELECT n + 1 FROM numbers WHERE n < 1000000
+)
+SELECT n FROM numbers;
+
+INSERT INTO product (name, price, stock, created_at, updated_at)
+SELECT
+    CONCAT('Product ', n) AS name,
+    FLOOR(RAND() * 1000) + 100 AS price,
+    FLOOR(RAND() * 1000) + 1 AS stock,
+    NOW() AS created_at,
+    NOW() AS updated_at
+FROM temp_numbers
+WHERE n <= 100000;
+
+INSERT INTO order_item (order_id, product_id, product_name, price, quantity, created_at, updated_at)
+SELECT
+    n AS order_id,
+    FLOOR(RAND() * 100000) + 1 AS product_id,
+    CONCAT('Product ', FLOOR(RAND() * 100000) + 1) AS product_name,
+    FLOOR(RAND() * 1000) + 100 AS price,
+    FLOOR(RAND() * 10) + 1 AS quantity,
+    DATE_SUB(NOW(), INTERVAL FLOOR(RAND() * 10) DAY) AS created_at,
+    NOW() AS updated_at
+FROM temp_numbers;
+
+DROP TEMPORARY TABLE IF EXISTS temp_numbers;

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -1,0 +1,23 @@
+DROP TABLE IF EXISTS order_item;
+DROP TABLE IF EXISTS product;
+
+CREATE TABLE product (
+                         id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                         name VARCHAR(255) NOT NULL,
+                         price BIGINT NOT NULL,
+                         stock BIGINT NOT NULL,
+                         created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                         updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+CREATE TABLE order_item (
+                            id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                            order_id BIGINT NOT NULL,
+                            product_id BIGINT NOT NULL,
+                            product_name VARCHAR(255) NOT NULL,
+                            price BIGINT NOT NULL,
+                            quantity BIGINT NOT NULL,
+                            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                            INDEX idx_order_item_product_created (product_id, created_at)
+) ENGINE=InnoDB;

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -19,5 +19,5 @@ CREATE TABLE order_item (
                             quantity BIGINT NOT NULL,
                             created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                             updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-                            INDEX idx_order_item_product_created (product_id, created_at)
+                            INDEX idx_order_item_product_created (product_id, created_at, quantity)
 ) ENGINE=InnoDB;


### PR DESCRIPTION
### **`STEP 15`**

- 나의 시나리오에서 수행하는 쿼리들을 수집해보고, 필요하다고 판단되는 인덱스를 추가하고 쿼리의 성능개선 정도를 작성하여 제출
    - 자주 조회하는 쿼리, 복잡한 쿼리 파악
    - Index 추가 전후 Explain, 실행시간 등 비교

## 학습 내용

<details>
<summary>인덱스(Index)</summary>

## 인덱스란?
- 인덱스는 데이터베이스에서 특정 컬럼의 값을 빠르게 검색하기 위해 사용되는 자료구조이다.  
- **읽기 성능**(SELECT)의 향상을 위해 사용하며, 조건(WHERE), 정렬(Order By), 그룹화(Group By) 등에 도움을 준다.
- 대부분 **B-Tree** 자료구조를 사용하며, 검색 범위를 빠르게 좁혀서 Full Table Scan을 피해 성능을 개선한다.

## B-Tree 인덱스와 탐색 방식

- **B-Tree(균형 트리) 구조**  : 대부분의 DBMS(MySQL, PostgreSQL, Oracle 등)에서 기본 인덱스로 사용한다.
- **성능** : B-Tree는 균형잡힌 구조 덕분에 항상 `O(log n)`의 시간 복잡도로 데이터를 탐색할 수 있다.
- **탐색 과정**  

  - **루트 노드** :  검색이 시작되는 최상위 노드에서 검색 범위를 결정할 키 값을 확인한다.
  - **중간 노드** : 각 노드는 여러 개의 키와 자식 포인터를 보유하며, 키 값을 비교하며 검색 경로를 좁힌다.
  - **리프 노드** : 실제 데이터의 위치(또는 데이터 자체)가 저장된 노드로, 최종적으로 원하는 데이터를 찾는다.
  

#### 기타 인덱스 
- Hash 인덱스: 키의 해시 값을 기반으로 직접 접근을 수행한다.
- GiST (Generalized Search Tree) 인덱스 : 지리정보나 복잡한 데이터 타입 등 다양한 비교 방식을 지원하는 데이터에 사용한다.
- GIN (Generalized Inverted Index) : 다대다 관계, 텍스트 검색에 적합하며 다수의 값이 포함된 컬럼을 효과적으로 인덱싱한다.
- R-Tree 인덱스 : 주로 좌표 기반의 공간 데이터를 저장하고 검색하는 데 사용한다.

## 인덱스 존재 여부에 따른 차이

- **인덱스가 없는 경우**  
   - `Full Table Scan`이 일어나기 때문에, DB가 테이블의 모든 행을 전부 확인해야 한다.  
   - 대량의 데이터가 쌓여 있을수록 검색 시간이 기하급수적으로 증가한다.

- **인덱스가 있는 경우**  
   - B-Tree 등의 자료구조를 통해 **검색 범위를 빠르게 좁힐 수** 있다.  
   - 원하는 데이터 위치를 빠르게 찾아가므로, 대규모 테이블에서도 검색 시간이 크게 단축된다.

## 인덱스 스캔
스캔(Scan)은 데이터베이스 내에서 특정 자료구조(테이블 또는 인덱스)의 데이터를 순차적으로 읽어  
검색 조건에 맞는 데이터를 찾는 과정을 의미한다.

### **Index Seek**
인덱스의 계층적 구조를 이용해 검색 조건에 부합하는 특정 값을 빠르게 찾는 방식이다. 검색 범위가 좁은 경우 매우 효율적이다.

### **Range Scan**
인덱스 상에서 특정 범위의 값들을 순차적으로 읽는 방식이다.  
예를 들어, `WHERE 컬럼 BETWEEN A AND B` 혹은 `WHERE 컬럼 > A` 와 같이 범위 조건이 있는 경우 사용된다.

### **Full Index Scan**
인덱스 전체를 처음부터 끝까지 순차적으로 탐색하는 방식이다.  
조건에 맞는 값을 찾기 위해 전체 인덱스를 읽어야 할 때 발생하며, 경우에 따라 비용이 많이 들 수 있다.

### **Index Only Scan (Covering Index Scan)**
쿼리에서 요청한 모든 컬럼의 데이터가 인덱스에 포함되어 있을 때,  
테이블의 실제 데이터를 조회하지 않고 인덱스만으로 쿼리를 처리하는 방식이다.  
이를 통해 I/O 비용을 줄일 수 있다.

## 인덱스 활용 시나리오
- WHERE 조건에 자주 등장하는 컬럼 (검색 빈도가 높은 컬럼)
- ORDER BY, GROUP BY에 자주 활용되는 컬럼
- 대규모 데이터 테이블에서 특정 범위를 빠르게 필터링해야 할 때
- 외래키(FK)처럼, 다른 테이블과 Join 시 연결 고리로 자주 쓰이는 컬럼

## 인덱스와 컬럼 타입
- **정수형** 컬럼에 대해 인덱스를 생성하면, B-Tree 내부에서 숫자 크기를 직접 비교하며 탐색한다.
- **문자열** 컬럼에 인덱스를 생성하면, DB의 `Collation`(문자 정렬 규칙)을 따라 **사전순**으로 비교하며 탐색한다.

## 인덱스와 카디널리티(Cardinality)
- 카디널리티란, 특정 컬럼이 가지는 값의 고유한 개수(중복도)를 의미한다.
- 카디널리티가 높은 컬럼(중복이 적고 값이 다양한 컬럼)이 일반적으로 인덱스 성능에 더 효과적이다.
  - 예: 주문번호(order_id), 사용자 ID(user_id) → 대부분 고유한 값이므로 인덱스 효율이 높음
- 카디널리티가 낮은 컬럼(중복이 많고 값이 적은 컬럼)은 단독 인덱스에서 인덱스 효과가 제한적이다.
  - 예: 성별(gender), 상태(status: 'ACTIVE', 'INACTIVE') → 값이 몇 개 없으므로 인덱스의 선택도가 낮아 효과가 떨어질 수 있음
> 복합 인덱스에서는 쿼리의 사용 패턴에 따라 카디널리티가 낮은 컬럼이 앞에 오는 것이 유리할 수도 있다.

## 인덱스 사용 시 읽기/쓰기 성능 비교
- **읽기(SELECT) 성능 향상**  
   - 인덱스를 사용하면 검색, 정렬, 그룹핑 등의 연산 속도가 빨라진다. 
   - WHERE 절에서 특정 컬럼을 자주 조회하거나 ORDER BY, GROUP BY 연산이 많을 경우 큰 성능 향상을 기대할 수 있다.
   - 하지만 불필요한 인덱스가 많으면 쿼리 최적화 과정에서 오버헤드가 발생하고, 최적의 인덱스를 선택하지 못해 성능이 저하될 수 있다.

- **쓰기(INSERT/UPDATE/DELETE) 성능 저하**  
   - 데이터를 추가, 수정, 삭제할 때 해당 테이블뿐만 아니라 관련 인덱스도 함께 갱신해야 한다.
   - 인덱스 개수가 많을수록 쓰기 연산 비용이 증가하며, 특히 UPDATE와 DELETE 시 인덱스 리밸런싱(재조정)이 발생할 수 있어 성능이 저하될 수 있다.
   - 빈번한 데이터 변경이 있는 경우 너무 많은 인덱스는 불필요한 오버헤드를 초래할 수 있다.

- **트레이드오프(Trade-off)**
   - 인덱스를 잘 설계하면 읽기 성능이 향상되지만, 쓰기 연산이 많은 경우 인덱스가 오히려 성능을 저하시킬 수 있다.
   - 서비스 특성(읽기 vs 쓰기 비중)을 고려하여 적절한 인덱스를 선정하는 것이 중요하다.
   - 실제 실행 계획(EXPLAIN, ANALYZE) 분석을 통해 인덱스가 쿼리 성능에 미치는 영향을 평가하고 최적화해야 한다.
> 일반적으로 쓰기 성능이 저하되더라도, 인덱스를 활용하면 읽기 성능이 훨씬 크게 향상되므로 전체적인 시스템 성능이 개선되는 경우가 많다. 특히, 조회 쿼리가 빈번한 환경에서는 적절한 인덱스 설계가 필수적이며, 인덱스가 없는 경우보다 훨씬 나은 성능을 제공한다.

</details>

<details>
<summary>복합 인덱스(Composite Index)</summary>

## 복합 인덱스(Composite Index)란?
- 복합 인덱스는 여러 컬럼을 하나의 인덱스로 결합하여 관리하는 방식이다.
- 이를 통해 다중 컬럼 조건 검색 시 최적화가 가능하며, 쿼리 실행 시 단일 인덱스보다 효과적인 성능 향상을 기대할 수 있다.
- 필요 시 커버링 인덱스(Covering Index)로 활용하면 테이블 접근 없이 인덱스만으로 쿼리 응답을 할 수 있어 효율적이다.

## 복합 인덱스의 기본 원칙

### 왼쪽 접두사(Left-most Prefix) 원칙
  
- 복합 인덱스는 인덱스에 포함된 컬럼의 순서가 검색 효율에 결정적인 영향을 미친다. `(A, B, C)`로 구성된 인덱스가 있을 때,
  
  - A 컬럼 : WHERE 절에서 A 컬럼에 대한 조건을 사용하면 인덱스의 전체 또는 상당 부분을 활용할 수 있다.
  - A, B 컬럼 : A와 B를 함께 사용하는 경우 두 컬럼 모두 인덱스에 의해 최적화된다.
  - B 또는 C 단독 : B나 C만 조건으로 사용할 경우, 왼쪽 접두사 원칙에 의해 성능 개선 효과가 미미할 수 있다.

### 범위 조건과 인덱스 사용
- 복합 인덱스의 컬럼에 범위 조건(`BETWEEN`, `>`, `<`)이 사용되면 그 이후의 컬럼들은 인덱스 활용에 제한이 있을 수 있다.
- 예 : (A, B, C) 인덱스에서 A에 대한 범위 조건이 있으면 B와 C는 인덱스를 활용할 수 없게 되거나, 활용도가 크게 낮아진다.
- 범위 조건이 포함된 쿼리는 인덱스의 순서에 따라 성능이 크게 달라질 수 있으므로  인덱스 설계 시 신중하게 고려해야 한다.

## 복합 인덱스 설계 시 고려 사항

### 카디널리티(Cardinality)
- 복합 인덱스에서는 무조건 카디널리티가 높은 컬럼을 앞에 두는 것이 아니라, WHERE 조건에서 자주 사용되며 필터링 효과가 큰 컬럼을 앞에 배치하는 것이 중요하다.
- 쿼리 사용 패턴에 따라 카디널리티가 낮은 컬럼이 앞에 오는 것이 유리할 수도 있다.

### 사용 패턴

- 자주 조회되거나 복잡한 쿼리에서 인덱스 사용 빈도를 파악하여 인덱스를 설계해야 한다.
- `WHERE`, `ORDER BY`, `GROUP BY`, `JOIN` 등에 자주 사용되는 컬럼을 기준으로 인덱스를 구성하면 쿼리 성능이 개선된다.

## 복합 인덱스의 단점 및 주의할 점
- 인덱스 크기 증가 : 여러 컬럼이 포함된 인덱스는 크기가 커지며 저장 공간을 더 많이 차지할 수 있다.
- 쓰기 성능 저하 : `INSERT`, `UPDATE`, `DELETE` 시 여러 컬럼이 포함된 인덱스를 함께 갱신해야 하므로 성능이 저하될 수 있다.
- 잘못된 인덱스 순서로 인한 비효율 : WHERE 절에서 자주 사용되는 컬럼이 인덱스 앞부분에 오지 않으면 인덱스 활용도가 떨어질 수 있다.
- 왼쪽 접두사 원칙을 벗어나는 쿼리가 생긴다면 , 조건에 맞는 별도의 인덱스를 생성하는 것이 필요할 수도 있다.

## 복합 인덱스와 JOIN 최적화
- 조인(Join) 시에도 복합 인덱스가 최적화에 영향을 미친다.
- `ON` 절에서 조인하는 컬럼이 복합 인덱스의 일부라면, 조인의 성능이 향상될 수 있다.
- 특히, 조인에서 자주 사용되는 컬럼을 복합 인덱스의 첫 번째 컬럼으로 설정하면 조인 성능이 개선될 가능성이 높다.
- 하지만, 조인 컬럼이 복합 인덱스의 첫 번째 컬럼이 아닐 경우, 인덱스가 제대로 활용되지 않을 수 있다.

</details>

<details>
<summary>인기 상품 조회 쿼리 분석과 인덱스 성능 비교</summary>

## 현재 쿼리

![인기상품](https://github.com/user-attachments/assets/c67b0022-f778-4f72-97bf-ff4fd33ed7a4)

## 쿼리 주요 흐름

- **JOIN**
  `Product`와 `OrderItem` 테이블을 내부 조인(inner join)한다.  
  조인 조건 1 :  `orderItem.productId = product.id`
  조인 조건 2 : `orderItem.createdAt >= LocalDateTime.now().minusDays(3)`
  
- **GROUP BY로 그룹화 및 집계**  
  조인된 결과를 `product.id` 기준으로 그룹화한 후, 각 상품별 주문 수량의 합계를 구한다.
  
- **ORDER BY, LIMIT 으로 정렬 및 제한** 
  주문 수량 합계 기준으로 내림차순 정렬하여 상위 5개의 상품을 가져온다.

## 현재 인덱스

![인기상품인덱스](https://github.com/user-attachments/assets/0dd8b3c4-6382-4d59-a6a9-837f30eea91d)

## 기대효과
- `product_id, created_at` 순서로 복합인덱스 적용
- 조인 최적화: orderItem.productId를 통해 Product와의 조인을 빠르게 처리할 수 있음
- 필터링 최적화: orderItem.createdAt 조건(>= threeDaysAgo)에 대해 효율적인 검색이 가능함

## 테스트 환경  
매 테스트마다 이전 테스트의 영향을 받지 않도록 컨테이너를 매번 새로 띄우는 방식으로 성능을 비교했다.  
MySQL 8.0부터 쿼리 캐싱(Query Cache)은 제거되었지만,  
InnoDB 버퍼 풀, 조인 버퍼, 정렬 버퍼, 임시 테이블 등의 메모리 기반 캐싱이 성능에 영향을 줄 수 있다고 한다.  
따라서 컨테이너를 재시작하여 내부 캐싱 효과를 제거하고, 쿼리 실행 시간을 정확히 비교할 수 있도록 했다.

## 테스트 절차
1. **기존 컨테이너 중지 및 삭제**  
2. **새 컨테이너 실행**  
3. **동일한 데이터 로드 및 인덱스 설정**  
4. **테스트 실행 및 결과 비교**  

대량 데이터 테스트를 위한 SQL 파일 추가 - 52621f8

## 인덱스 별 테스트

<details>
<summary>기본 인덱스(PK) 테스트</summary>

![인덱스 x](https://github.com/user-attachments/assets/2b35f665-e4d1-4512-ad39-95bf09abca57)

✅ 실행 계획(EXPLAIN)

- `order_item` 테이블을 전체 1,000,000건 스캔
- WHERE 조건으로 약 33% 필터링
- 그룹화 및 정렬을 위해 임시 테이블과 파일 정렬(filesort) 사용
- `product` 테이블은 기본 키(PK)를 통해 효율적으로 조회

✅ 실제 실행 속도
- 0.63초 소요 → 반복 실행시 평균 실행 시간 0.6초 대 유지

✅ 분석
- order_item 테이블에서 created_at 필터링 시 FULL SCAN 발생
- GROUP BY 및 ORDER BY SUM(o.quantity) DESC로 인해 임시 테이블 사용
- 쿼리 실행 순서상 order_item을 먼저 조회해야 하는데, 인덱스가 없으므로 비효율적인 탐색이 발생

</details>

<details>
<summary>복합 인덱스(product_id, created_at) 테스트</summary>

![복합인덱스1](https://github.com/user-attachments/assets/be49538b-100c-46d7-bba9-3bd47593d215)

✅ 실행 계획(EXPLAIN)
- `product` 테이블의 PK 인덱스를 통해 약 100,000건의 인덱스 스캔 후, `order_item`은 `ref` 방식으로 조회
- GROUP BY 및 ORDER BY로 인해 여전히 임시 테이블과 파일 정렬(filesort) 발생

✅ 실제 실행 속도
 - 1.14초 소요 → 반복 실행시 평균 실행 시간 0.6~0.7초 대 유지

✅ 분석
- 복합 인덱스 적용 후 조회 속도 저하 원인:  옵티마이저가 인덱스를 활용해 조인 성능을 개선했지만,  `GROUP BY` 및 `ORDER BY` 처리 과정에서 임시 테이블과 파일 정렬(filesort)이 발생 → 추가적인 오버헤드 발생  
- `order_item` 테이블에서 많은 행을 필터링해야 하며, 인덱스를 사용해 조회된 데이터도 정렬 및 그룹화 과정에서 메모리 또는 디스크 I/O 부담이 증가  
- 첫 실행은 디스크 I/O로 인해 느리지만, InnoDB 버퍼 풀 캐싱으로 인해 반복 실행 시 속도가 개선된다고 함
- 그러나 인덱스 없이 실행했을 때보다 정렬 및 임시 테이블 오버헤드가 커져 전체적인 실행 성능이 오히려 저하됨
  - 인덱스가 필터링과 조인 성능을 개선했지만, 정렬 과정에서 오히려 더 많은 리소스를 소모  
  - 랜덤 I/O 증가, 임시 테이블 생성 비용 증가로 인해 실행 속도가 느려짐  

> 인덱스가 조인 성능을 향상시키지만, 정렬 및 집계 연산이 포함된 경우 전체적인 쿼리 성능이 오히려 저하될 수 있음  
> SUM(o.quantity) 집계 연산을 최적화하기 위해 커버링 인덱스 적용하면 개선할 수 있어 보임 (quantity 컬럼을 인덱스에 포함)


</details>

<details>
<summary>복합 인덱스(product_id, created_at, quantity) 테스트</summary>

![복합인덱스2](https://github.com/user-attachments/assets/37858190-037d-4d1f-9387-8af17c5e9bdb)


✅ 실행 계획(EXPLAIN) 분석
- `product` 테이블은 PK를 통해 순차적으로 스캔
- `order_item` 테이블은 인덱스를 활용해 빠른 필터링 (`created_at >= ...`), 조인 (`product_id`) 수행
- GROUP BY와 ORDER BY는 여전히 임시 테이블 및 파일 정렬을 사용하지만,인덱스 덕분에 처리해야 할 데이터 범위가 크게 줄어든다.

✅ 실제 실행 속도 분석
 - 0.25초 소요 → 반복 실행시 평균 실행 시간 0.21 ~ 0.22초 유지

✅ 분석
- 인덱스에 `quantity` 컬럼 포함 → **커버링 인덱스** 효과
- `SUM(o.quantity)` 집계 연산을 인덱스만으로 처리 가능하여 추가 테이블 조회 없이 효율적 집계 수행

#### 커버링 인덱스
쿼리에서 필요한 모든 컬럼을 인덱스에 포함시켜, 데이터 행 자체를 읽지 않고 인덱스만으로 쿼리 결과를 제공하는 기법  
이로 인해 I/O가 줄어들어 쿼리 성능이 크게 향상된다.
</details>


<details>
<summary>복합 인덱스(created_at, product_id, quantity) 테스트</summary>

![복합인덱스 순서바꾸면](https://github.com/user-attachments/assets/aa1727a1-8611-4434-8937-3f8874901786)
✅ 실행 계획(EXPLAIN) 분석
- product_id와 created_at의 순서를 변경하면 실행 계획에서 더 많은 데이터 Rows를 읽어오는걸 확인할 수 있다.(100000 -> 500000)

✅ 실제 실행 속도 분석
- 0.47초 소요 → 반복 실행시 평균 실행 시간 0.4초대 유지 - 순서 변경 전 보다 두배 느림

✅ 분석 - created_at 컬럼을 복합 인덱스 첫 컬럼으로 두면 더 느린 이유

현재 데이터 생성 로직에서 created_at 값은 0~10일 전으로 균등하게 분포되어 있다.
WHERE created_at >= NOW() - INTERVAL 3 DAY 조건이 걸리면, order_item 테이블의 약 30%가 조회 대상이 된다.
결과적으로, 너무 많은 행이 필터링 범위에 포함되므로 MySQL이 인덱스를 효율적으로 활용하지 못하고, 풀스캔에 가까운 동작을 하게 된다.
따라서 현재 상황에서는 WHERE 필터링보다, 조인 성능을 최적화할 수 있는 product_id를 앞에 두는 것이 더 나은 선택이다.

> 만약 데이터 분포가 최근 3일치가 전체의 5~10%만 차지하는 구조였다면 created_at을 앞에 두는 것이 유리할 수 있고, 실제 운영되는 데이터는 그럴 가능성이 높을 것이다.

</details>

## 성능 비교 요약
- 기본 인덱스(PK) 테스트 - 평균 쿼리 속도: 0.65s
- 복합 인덱스(product_id, created_at) 테스트 - 평균 쿼리 속도: 1.1s ~ 0.7s (실행 횟수에 따라 다름)
- 복합 인덱스(created_at, product_id, quantity) 테스트- 평균 쿼리 속도 : 0.45s
- 복합 인덱스(product_id, created_at, quantity) 테스트- 평균 쿼리 속도 : 0.22s

> 복합 인덱스에 `quantity`를 포함하여 커버링 인덱스 적용 후 집계 및 조인 성능이 개선되어 전체 쿼리 실행 속도가 향상되었다.



</details>


## PR 설명
feat: 인덱스 성능 비교를 위한 product, order_item 더미 데이터 생성 파일 추가 - 52621f8
refactor: 인기 상품 조회에서 가장 조회 성능이 빠른 인덱스로 변경 - 0fca45f


## 리뷰 포인트

인덱스를 적용해도 쓰기 성능이 엄청나게 빨라지진 않았는데, 각각의 인덱스 테스트 분석에서 잘못 판단 한 부분이 있는지 궁금합니다.

인덱스 테스트 방식이나, 인덱스 성능을 비교하는 부분에서 생각못한 부분이 많을 것 같은데, 어떤 부분을 더 생각해볼 수 있을까요?  

## KPT

#### Keep
과제 완료하고 제출하기

#### Problem
인덱스 분석이 제대로 된건지 모르겠다.

#### Try
피드백 듣고 부족한 부분 보완하기
